### PR TITLE
ci(android): build APKs for all architectures and improve artifact up…

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,9 +12,15 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - arch: arm64-v8a
+          - arch: armeabi-v7a
+          - arch: x86_64
+          - arch: x86
 
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -55,16 +61,16 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew assemble
 
-      - name: Upload Release Build Artifact
+      - name: Upload ${{ matrix.arch }}  Release Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: apk-files-release
-          path: app/build/outputs/apk/release
+          path: app/build/outputs/apk/release/**${{ matrix.goos }}**.apk
           if-no-files-found: error
 
-      - name: Upload Debug Build Artifact
+      - name: Upload ${{ matrix.arch }} Debug Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: apk-files-debug
-          path: app/build/outputs/apk/debug
+          path: app/build/outputs/apk/debug/**${{ matrix.goos }}**.apk
           if-no-files-found: error

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.api.BaseVariantOutputImpl
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -44,6 +46,12 @@ android {
             isUniversalApk = false
             reset()
             include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+        }
+    }
+    applicationVariants.all {
+        outputs.all {
+            this as BaseVariantOutputImpl
+            this.outputFileName = "${rootProject.name.lowercase()}-${versionName}.${name}.apk"
         }
     }
 }


### PR DESCRIPTION
…load

- Update GitHub Actions workflow to build APKs for arm64-v8a, armeabi-v7a, x86_64, and x86 architectures
- Modify APK naming convention to include architecture type
- Update artifact upload process to handle multiple architectures
- Improve error handling for missing APK files